### PR TITLE
fix bug interpreting booleans as ints

### DIFF
--- a/src/pydiesel/reflection/types/reflected_type.py
+++ b/src/pydiesel/reflection/types/reflected_type.py
@@ -61,6 +61,8 @@ class ReflectedType(object):
             return obj
         elif obj_type == None and isinstance(obj, long) or obj_type == "long":
             return cls.reflected_primitive("long", obj, reflector=reflector)
+        elif obj_type == None and isinstance(obj, bool) or obj_type == "boolean":
+            return cls.reflected_primitive("boolean", obj, reflector=reflector)
         elif obj_type == None and isinstance(obj, int) or obj_type == "int":
             return cls.reflected_primitive("int", obj, reflector=reflector)
         elif obj_type == "byte" and isinstance(obj, int):
@@ -71,8 +73,6 @@ class ReflectedType(object):
             return cls.reflected_primitive("short", obj, reflector=reflector)
         elif obj_type == None and isinstance(obj, float) or obj_type == "float":
             return cls.reflected_primitive("float", obj, reflector=reflector)
-        elif obj_type == None and isinstance(obj, bool) or obj_type == "boolean":
-            return cls.reflected_primitive("boolean", obj, reflector=reflector)
         elif obj_type == "data":
             return cls.reflected_binary(obj, reflector=reflector)
         elif obj_type == None and (isinstance(obj, str) or isinstance(obj, unicode)) or obj_type == "string":


### PR DESCRIPTION
Every boolean passed to drozer-agent got interpreted as int, because in python booleans are integers ( isinstance(True, int) == True ).
