### PR TITLE
Fix extension getClassLoader runtime error with pyenv

### DIFF
--- a/src/pydiesel/reflection/utils/class_loader.py
+++ b/src/pydiesel/reflection/utils/class_loader.py
@@ -12,10 +12,10 @@ class ClassLoader(object):
     Provides utility methods for loading Java source code from the local
     system into the running Dalvik VM, using the reflection API.
     """
-    
+
     def __init__(self, source_or_relative_path, cache_path, construct, system_class_loader, relative_to=None):
         self.source_or_relative_path = source_or_relative_path
-        
+
         self.android_path = None
         self.cache_path = cache_path
         self.construct = construct
@@ -26,23 +26,23 @@ class ClassLoader(object):
 
     def loadClass(self, klass):
         return self.getClassLoader().loadClass(klass);
-        
+
     def getClassLoader(self):
         """
         Gets a DexClassLoader on the agent, given compiled source or an apk
         file from the local system.
         """
-        
+
         self.source = self.__get_source(self.source_or_relative_path, relative_to=self.relative_to)
 
         if self.source != None:
             file_path = "/".join([self.cache_path, self.__get_cached_apk_name()])
-    
+
             file_io = self.construct('java.io.File', file_path)
-            
-            if not self.__verify_file(file_io, self.source):  
+
+            if not self.__verify_file(file_io, self.source):
                 source_data = [ReflectedPrimitive("byte", (ord(i) if ord(i) < 128 else ord(i) - 0x100), reflector=None) for i in self.source]
-    
+
                 file_stream = self.construct("java.io.FileOutputStream", file_path)
                 file_stream.write(source_data, 0, len(source_data))
                 file_stream.close()
@@ -55,25 +55,25 @@ class ClassLoader(object):
         Calculate a unique name for the cached APK file, based on the content
         of the library file.
         """
-        
+
         return binascii.hexlify(hashlib.md5(self.source).digest()) + ".apk"
-    
+
     def __get_source(self, source_or_relative_path, relative_to=None):
         """
         Get source, either from an apk file or passed directly.
         """
-        
+
         source = None
 
         if source_or_relative_path.endswith(".apk"):
             if relative_to == None:
                 relative_to = os.path.join(os.path.dirname(__file__), "..")
-            elif relative_to.find(".py") >= 0 or relative_to.find(".pyc") >= 0:
+            elif relative_to.endswith(".py") or relative_to.endswith(".pyc"):
                 relative_to = os.path.dirname(relative_to)
-                
+
             apk_path = os.path.join(relative_to, *source_or_relative_path.split("/"))
             java_path = apk_path.replace(".apk", ".java")
-            
+
             if os.path.exists(apk_path):
                 source = fs.read(apk_path)
             elif os.path.exists(java_path):
@@ -93,15 +93,15 @@ class ClassLoader(object):
             no file present on the agent
             """
             return False
-        
-        remote_hash = ""        
+
+        remote_hash = ""
         try:
             remote_verify = self.construct("com.mwr.dz.util.Verify")
             remote_hash = remote_verify.md5sum(remote)
         except ReflectionException:
             return True
-            
+
         local_hash = md5.new(local_data).digest().encode("hex")
-        
+
         return remote_hash == local_hash
-        
+


### PR DESCRIPTION
When install pyenv in ~/.pyenv, it contains ".py" that __get_source will
treat any relative_to path as python file.

It cause

self.loadClass("common/XmlAssetReader.apk", "XmlAssetReader")

search
~/.pyenv/versions/2.7.15/lib/python2.7/site-packages/drozer/modules/common/common/XmlAssetReader.apk

but actually should be
~/.pyenv/versions/2.7.15/lib/python2.7/site-packages/drozer/modules/common/../common/XmlAssetReader.apk